### PR TITLE
Refactored SpecModal and PlanModal to deduplicate validation logic

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -53,7 +53,15 @@ const defaultSettings = createBabelSettings({
 const frontendSettings = createBabelSettings({
   envSettings: {
     targets: {
-      browsers: ['last 2 versions'],
+      browsers: [
+        'last 2 Chrome versions',
+        'last 2 ChromeAndroid versions',
+        'last 2 Firefox versions',
+        'Firefox ESR',
+        'last 1 Edge version',
+        'IE 11',
+        'last 1 Safari version',
+      ],
     },
   },
 });
@@ -73,7 +81,7 @@ module.exports = api => {
     ...defaultSettings,
     overrides: [
       {
-        test: 'src/frontend',
+        test: ['src/frontend', 'src/view'],
         ...frontendSettings,
       },
     ],

--- a/src/state/SpecState.tsx
+++ b/src/state/SpecState.tsx
@@ -1,5 +1,5 @@
 import { client } from 'client/BackendClient';
-import { observable, computed, action } from 'mobx';
+import { observable, computed, action, runInAction } from 'mobx';
 import { HasId } from 'model/Entity';
 import { Spec } from 'model/Spec';
 
@@ -37,5 +37,7 @@ client
   .service('specifications')
   .find()
   .then(json => {
-    json.map(spec => state.specs.set(spec.id, spec));
+    runInAction(() => {
+      json.map(spec => state.specs.set(spec.id, spec));
+    });
   });

--- a/src/view/Overview.tsx
+++ b/src/view/Overview.tsx
@@ -1,5 +1,6 @@
 import IconButton from '@material-ui/core/IconButton';
 import AddIcon from '@material-ui/icons/Add';
+import { runInAction } from 'mobx';
 import { Observer } from 'mobx-react';
 import React, { Component } from 'react';
 import { RouteComponentProps } from 'react-router';
@@ -22,7 +23,7 @@ export class Overview extends Component<RouteComponentProps<{}>, {}> {
   private openAddPlanModal = () =>
     this.props.history.push(`${this.props.match.url}/plan/add`);
   private goToSpec = spec => this.props.history.push(`/specs/${spec.id}`);
-  private expandSpec = id => (state.expandedSpecId = id);
+  private expandSpec = id => runInAction(() => (state.expandedSpecId = id));
 
   public render() {
     return (

--- a/src/view/basic/SpecItem.tsx
+++ b/src/view/basic/SpecItem.tsx
@@ -12,6 +12,7 @@ import {
   ExpansionPanelSummary,
   ExpansionPanelDetails,
   Table,
+  TableBody,
 } from '@material-ui/core';
 import * as Icons from '@material-ui/icons';
 import classNames from 'classnames';
@@ -137,9 +138,11 @@ export class SpecItem extends Component<SpecItemProps> {
                   </div>
                 </div>
                 <Table classes={{ root: classNames(classes.sdkList, classes.bordered) }}>
-                  {plans.map(plan => (
-                    <PlanItem plan={plan} />
-                  ))}
+                  <TableBody>
+                    {plans.map(plan => (
+                      <PlanItem key={plan.id} plan={plan} />
+                    ))}
+                  </TableBody>
                 </Table>
                 <List>
                   <ListItem className={classes.sdkHeaderActions}>

--- a/src/view/basic/SpecModal.tsx
+++ b/src/view/basic/SpecModal.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { MouseEvent } from 'react';
 
 import {
   Button,
@@ -11,10 +11,15 @@ import {
 } from '@material-ui/core';
 import { ButtonProps } from '@material-ui/core/Button';
 import { ModalProps } from '@material-ui/core/Modal';
-import { observable, action, computed } from 'mobx';
 import { Observer } from 'mobx-react';
 
 import { FloatingModal } from 'basic/FloatingModal';
+import {
+  ValidatedForm,
+  inputValid,
+  inputInvalid,
+  alwaysValid,
+} from 'basic/ValidatedForm';
 import { Category } from 'model/Storybook';
 import { AddedSpec } from 'state/SpecState';
 import { isWebUri } from 'valid-url';
@@ -40,17 +45,6 @@ const Styled: any = createStyled(theme => ({
   },
 }));
 
-export interface FormText {
-  title: string;
-  url: string;
-  description: string;
-}
-
-export interface FormError {
-  title?: string;
-  url?: string;
-}
-
 export type OnCloseModal = () => void;
 export type OnSubmitSpec = (spec: AddedSpec) => void;
 export interface SpecModalProps {
@@ -62,137 +56,63 @@ export interface SpecModalProps {
   readonly modalProps?: ModalProps;
 }
 
+type SpecModalInput = 'title' | 'url' | 'description';
+
 /**
  * A modal window that allows the user to add a Spec to the dashboard.
  * Currently only supports specifying a name and URL.
  */
-export class SpecModal extends Component<SpecModalProps> {
-  /**
-   * Currently entered form data
-   */
-  @observable
-  private readonly formText: FormText = {
-    title: '',
-    url: '',
-    description: '',
-  };
-
-  /**
-   * Current error messages (if any) for each form field
-   */
-  @observable
-  private readonly error: FormError = {
-    title: undefined,
-    url: undefined,
-  };
-
-  /**
-   * @returns An error message if the title is invalid in some way
-   */
-  @computed
-  get titleError(): string | undefined {
-    const title = this.formText.title;
-    return !title ? 'Error: Missing title' : undefined;
+export class SpecModal extends ValidatedForm<SpecModalInput, SpecModalProps> {
+  constructor(props: Readonly<SpecModalProps>) {
+    super(
+      {
+        title: {
+          validation: title =>
+            !title ? inputInvalid('Error: Missing title') : inputValid(),
+          initialValue: '',
+        },
+        url: {
+          validation: url => {
+            if (!url) {
+              return inputInvalid('Error: URL cannot be empty');
+            } else if (!isWebUri(url)) {
+              return inputInvalid('Error: Invalid URL');
+            }
+            return inputValid();
+          },
+          initialValue: '',
+        },
+        description: {
+          validation: alwaysValid,
+          initialValue: '',
+        },
+      },
+      props,
+    );
   }
-
-  /**
-   * @returns An error message if the url is invalid in some way
-   */
-  @computed
-  get urlError(): string | undefined {
-    const url = this.formText.url;
-    if (!url) {
-      return 'Error: URL cannot be empty';
-    } else if (!isWebUri(url)) {
-      return 'Error: Invalid URL';
-    } else {
-      return undefined;
-    }
-  }
-
-  /**
-   * Checks whether the Spec's URL input is valid
-   * @param showErrorMesssage If false, clear the error message
-   */
-  @action
-  private validateUrl = (showErrorMesssage: boolean = true): boolean => {
-    let valid: boolean;
-    if (this.urlError) {
-      if (showErrorMesssage) {
-        this.error.url = this.urlError;
-      }
-      valid = false;
-    } else {
-      this.error.url = undefined;
-      valid = true;
-    }
-    return valid;
-  };
-
-  /**
-   * Checks whether the Spec's title input is valid
-   * @param showErrorMesssage If false, clear the error message
-   */
-  @action
-  private validateTitle = (showErrorMesssage: boolean = true): boolean => {
-    let valid: boolean;
-    if (this.titleError) {
-      if (showErrorMesssage) {
-        this.error.title = this.titleError;
-      }
-      valid = false;
-    } else {
-      this.error.title = undefined;
-      valid = true;
-    }
-    return valid;
-  };
-
-  /**
-   * @param showErrorMessages If false, only clears validation errors rather than adding them.
-   * @returns true if the input was valid, false otherwise.
-   */
-  @action
-  private validateAllInputs = (showErrorMessages: boolean = true) => {
-    const titleValid = this.validateTitle(showErrorMessages);
-    const urlValid = this.validateUrl(showErrorMessages);
-    return titleValid && urlValid;
-  };
 
   /**
    * Event fired when the user presses the 'Add' button.
    */
-  @action
   private onSubmitSpec = () => {
     // Validate input
-    if (!this.validateAllInputs()) {
+    if (!this.inputsValid) {
+      this.updateAllInputErrors();
       return;
     }
 
     // Send the request to the backend
-    const title = this.formText.title;
-    const path = isWebUri(this.formText.url);
-    const description = this.formText.description;
+    const title = this.getInputValue('title');
+    const path = isWebUri(this.getInputValue('url'));
+    const description = this.getInputValue('description');
     this.props.onSubmitSpec({ title, path, description });
   };
 
-  private onTitleChange = event => {
-    this.formText.title = event.target.value;
-    this.validateTitle(false);
-  };
+  private onInputChange = event =>
+    this.setInputValue(event.target.id as SpecModalInput, event.target.value);
+  private onInputBlur = event => this.updateInputError(event.target.id as SpecModalInput);
 
-  private forceValidateTitle = () => this.validateTitle();
-
-  private onUrlChange = event => {
-    this.formText.url = event.target.value;
-    this.validateUrl(false);
-  };
-
-  private forceValidateUrl = () => this.validateUrl();
-
-  private onFormTextChange = event => (this.formText.description = event.target.value);
-
-  private onAddButtonClick = event => {
+  private onAddButtonClick = (event: MouseEvent<HTMLElement>) => {
     event.preventDefault();
     this.onSubmitSpec();
   };
@@ -223,40 +143,51 @@ export class SpecModal extends Component<SpecModalProps> {
                     <Typography variant="title" className={classes.title}>
                       Add Swagger Spec
                     </Typography>
-                    <FormControl error={this.error.title !== undefined} margin="normal">
+                    <FormControl
+                      error={this.getInputError('title') !== null}
+                      margin="normal"
+                    >
                       <InputLabel htmlFor="title">Title</InputLabel>
                       <Input
                         id="title"
-                        onChange={this.onTitleChange}
-                        onBlur={this.forceValidateTitle}
-                        value={this.formText.title}
+                        onChange={this.onInputChange}
+                        onBlur={this.onInputBlur}
+                        value={this.getInputValue('title')}
                       />
                       <FormHelperText>
-                        {this.error.title || 'E.g. Petstore'}
+                        {this.getInputError('title') || 'E.g. Petstore'}
                       </FormHelperText>
                     </FormControl>
-                    <FormControl error={this.error.url !== undefined} margin="dense">
+                    <FormControl
+                      error={this.getInputError('url') !== null}
+                      margin="dense"
+                    >
                       <InputLabel htmlFor="url">URL</InputLabel>
                       <Input
                         id="url"
-                        onChange={this.onUrlChange}
-                        onBlur={this.forceValidateUrl}
-                        value={this.formText.url}
+                        onChange={this.onInputChange}
+                        onBlur={this.onInputBlur}
+                        value={this.getInputValue('url')}
                       />
                       <FormHelperText>
-                        {this.error.url ||
+                        {this.getInputError('url') ||
                           'E.g. http://petstore.swagger.io/v2/swagger.json'}
                       </FormHelperText>
                     </FormControl>
-                    <FormControl margin="dense">
+                    <FormControl
+                      error={this.getInputError('description') !== null}
+                      margin="dense"
+                    >
                       <InputLabel htmlFor="description">Description</InputLabel>
                       <Input
                         id="description"
-                        onChange={this.onFormTextChange}
-                        value={this.formText.description}
+                        onChange={this.onInputChange}
+                        onBlur={this.onInputBlur}
+                        value={this.getInputValue('description')}
                         multiline
                         rowsMax={3}
                       />
+                      <FormHelperText>{this.getInputError('description')}</FormHelperText>
                     </FormControl>
                   </div>
 

--- a/src/view/basic/ValidatedForm.tsx
+++ b/src/view/basic/ValidatedForm.tsx
@@ -1,0 +1,193 @@
+import { observable, action, computed, comparer, IComputedValue } from 'mobx';
+import { Component } from 'react';
+
+/**
+ * Represents the result of an input validation function where the input is determined to be valid.
+ */
+interface ValidationResultOk {
+  valid: true;
+  reason?: never;
+}
+
+/**
+ * Represents the result of an input validation function where the input is determined to be
+ * invalid.
+ */
+interface ValidationResultError {
+  valid: false;
+
+  /**
+   * A message describing why the input is invalid.
+   */
+  reason: string;
+}
+
+/**
+ * Represents the result of an input validation function.
+ */
+export type ValidationResult = ValidationResultOk | ValidationResultError;
+
+/**
+ * Represents an input validation function that determines whether or not a given input is valid.
+ */
+export type ValidationFunction = (value: string) => ValidationResult;
+
+/**
+ * Returns a ValidationResultOk, indicating that an input was valid.
+ */
+export const inputValid: () => ValidationResult = () => ({ valid: true });
+
+/**
+ * Returns a ValidationResult indicating that an input was invalid, along with a reason why it was
+ * invalid.
+ */
+export const inputInvalid: (reason: string) => ValidationResult = reason => ({
+  valid: false,
+  reason,
+});
+
+/**
+ * A ValidationFunction that always returns a ValidationResultOk.
+ */
+export const alwaysValid: ValidationFunction = (value: string) => inputValid();
+
+/**
+ * A base class for implementing forms with input validation logic.
+ *
+ * Note that this class should be marked as `abstract`, however there is a bug preventing the use of
+ * decorators within abstract classes: https://github.com/babel/babel/issues/8172
+ *
+ * @template I A string literal type defining the names of the form inputs in the form.
+ */
+export class ValidatedForm<I extends string, P = {}, S = {}> extends Component<P, S> {
+  /**
+   * Maps each form input to its validation function, wrapped in a MobX computed value.
+   */
+  private readonly inputValidationFunctions: Map<
+    I,
+    IComputedValue<ValidationResult>
+  > = new Map();
+
+  /**
+   * Maps each form input to its current value.
+   */
+  @observable
+  private readonly inputValues: Map<I, string> = new Map();
+
+  /**
+   * Maps each form input to its current error message. If a form input is not
+   */
+  @observable
+  private readonly inputErrors: Map<I, string> = new Map();
+
+  /**
+   * Creates the ValidatedForm.
+   *
+   * @param inputs An object describing the how each input should be validated, and what its initial
+   *               value should be
+   * @param inputs.validation A ValidationFunction called each time the input needs to be validated.
+   * @param inputs.initialValue The initial value of the input.
+   */
+  protected constructor(
+    inputs: { [key in I]: { validation: ValidationFunction; initialValue: string } },
+    props: Readonly<P>,
+  ) {
+    super(props);
+    for (const input of Object.keys(inputs) as I[]) {
+      const validate = inputs[input].validation;
+      this.inputValidationFunctions.set(
+        input,
+        computed(() => validate(this.getInputValue(input)), {
+          equals: comparer.structural,
+        }),
+      );
+      this.setInputValue(input, inputs[input].initialValue);
+    }
+  }
+
+  private validateInput(input: I): ValidationResult {
+    return (this.inputValidationFunctions.get(input) as IComputedValue<
+      ValidationResult
+    >).get();
+  }
+
+  @action
+  private clearInputError(input: I) {
+    this.inputErrors.delete(input);
+  }
+
+  @action
+  private setInputError(input: I, error: string) {
+    this.inputErrors.set(input, error);
+  }
+
+  /**
+   * Evaluates to true if all form inputs are valid, false otherwise.
+   */
+  @computed
+  protected get inputsValid(): boolean {
+    let valid = true;
+    for (const [input] of this.inputValues) {
+      valid = valid && this.validateInput(input).valid;
+      if (!valid) {
+        break;
+      }
+    }
+    return valid;
+  }
+
+  /**
+   * Gets the current value of the given form input.
+   */
+  protected getInputValue(input: I): string {
+    return this.inputValues.get(input) as string;
+  }
+
+  /**
+   * Sets the value of the given form input to the given string.
+   */
+  @action
+  protected setInputValue(input: I, value: string) {
+    this.inputValues.set(input, value);
+    if (this.getInputError(input) !== null) {
+      const result = this.validateInput(input);
+      if (result.valid) {
+        // An error message was displayed, but now the used has fixed the reason
+        this.clearInputError(input);
+      } else if (result.reason !== this.getInputError(input)) {
+        // The displayed error message has now changed to a different one
+        this.setInputError(input, result.reason);
+      }
+    }
+  }
+
+  /**
+   * Gets the current error message associated with the given form input, or null if the form input
+   * has no current error message.
+   */
+  protected getInputError(input: I): string | null {
+    if (this.inputErrors.has(input)) {
+      return this.inputErrors.get(input) as string;
+    }
+    return null;
+  }
+
+  /**
+   * Validates the given form input, updating its associated error message if the validation failed.
+   */
+  protected updateInputError(input: I) {
+    const result = this.validateInput(input);
+    if (!result.valid) {
+      this.setInputError(input, result.reason);
+    }
+  }
+
+  /**
+   * Validates all form inputs, updating any associated error messages where validation fails.
+   */
+  protected updateAllInputErrors() {
+    this.inputValues.forEach((value, input) => {
+      this.updateInputError(input);
+    });
+  }
+}


### PR DESCRIPTION
Also ensured all MobX state changes are made inside an action as this is best practice, and fixed a missing <TableBody> element that was causing console errors.

I also fixed Babel failing to transpire and files in `src/view`, and replaced `last 2 versions` in the Babel browser list config with a more concrete list, as [`last 2 versions` is considered very bad practice](https://jamie.build/last-2-versions).