### PR TITLE
Added a lerna.json for npm releases

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,26 @@
+{
+  "lerna": "3.2.1",
+  "version": "1.0.0-alpha.0",
+  "changelog": {
+    "repo": "PatrickShaw/by-example",
+    "cacheDir": ".changelog"
+  },
+  "packages": [
+    "build-packages/*",
+    "packages/*"
+  ],
+  "npmClient": "yarn",
+  "npmClientArgs": [
+    "--no-lockfile"
+  ],
+  "command": {
+    "publish": {
+      "ignoreChanges": [
+        "*.md",
+        "test/**",
+        "*.log",
+        "openapi-platform.config*"
+      ]
+    }
+  }
+}

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "lerna": "3.2.1",
   "version": "1.0.0-alpha.0",
   "changelog": {
-    "repo": "PatrickShaw/by-example",
+    "repo": "telstra/opeanpi-platform",
     "cacheDir": ".changelog"
   },
   "packages": [


### PR DESCRIPTION
We needed a way of releasing all our npm packages easily and automatically updating their versions.
Lerna is a pretty popular way of doing so. Jest, Babel and Storybook are good examples of monorepos that use Lerna.

This Pr adds a lerna.json to the repo.
Should be as easy as `lerna publish` to publish our packages to the npm registry.