### PR TITLE
Add ability to specify Git repository information for SDK configs

### DIFF
--- a/packages/frontend-dist/src/ValidatedFormStore.tsx
+++ b/packages/frontend-dist/src/ValidatedFormStore.tsx
@@ -29,7 +29,10 @@ export type ValidationResult = ValidationResultOk | ValidationResultError;
 /**
  * Represents an input validation function that determines whether or not a given input is valid.
  */
-export type ValidationFunction = (value: string) => ValidationResult;
+export type ValidationFunction<I extends string> = (
+  value: string,
+  inputStore?: ValidatedFormStore<I>,
+) => ValidationResult;
 
 /**
  * Returns a ValidationResultOk, indicating that an input was valid.
@@ -91,13 +94,13 @@ export class ValidatedFormStore<I extends string> {
    * @param inputs.initialValue The initial value of the input.
    */
   public constructor(
-    inputs: { [key in I]: { validation: ValidationFunction; initialValue: string } },
+    inputs: { [key in I]: { validation: ValidationFunction<I>; initialValue: string } },
   ) {
     for (const input of Object.keys(inputs) as I[]) {
       const validate = inputs[input].validation;
       this.inputValidationFunctions.set(
         input,
-        computed(() => validate(this.getInputValue(input)), {
+        computed(() => validate(this.getInputValue(input), this), {
           equals: comparer.structural,
         }),
       );

--- a/packages/frontend-dist/src/state/SdkConfigState.tsx
+++ b/packages/frontend-dist/src/state/SdkConfigState.tsx
@@ -37,7 +37,6 @@ class SdkConfigState {
     const updatedSdkConfigStore: SdkConfig = {
       ...updatedSdkConfig,
       buildStatus: currentConfig!.buildStatus,
-      gitInfo: currentConfig!.gitInfo,
       specId: currentConfig!.specId,
     };
     const sdkConfig: HasId<SdkConfig> = await client

--- a/packages/frontend-dist/src/state/SdkConfigState.tsx
+++ b/packages/frontend-dist/src/state/SdkConfigState.tsx
@@ -1,6 +1,6 @@
 import { observable, computed, action } from 'mobx';
 
-import { HasId, Id, SdkConfig } from '@openapi-platform/model';
+import { HasId, Id, SdkConfig, GitInfo } from '@openapi-platform/model';
 import { client } from '../client';
 
 class SdkConfigState {
@@ -51,7 +51,8 @@ export interface AddedSdkConfig {
   specId?: number;
   target: string;
   version?: string;
-  options?: any;
+  options: any;
+  gitInfo?: GitInfo;
 }
 
 export const state: SdkConfigState = new SdkConfigState();

--- a/packages/frontend-dist/src/state/SpecState.tsx
+++ b/packages/frontend-dist/src/state/SpecState.tsx
@@ -1,4 +1,4 @@
-import { HasId, Spec, SdkConfig } from '@openapi-platform/model';
+import { HasId, Spec } from '@openapi-platform/model';
 import { observable, computed, action } from 'mobx';
 import { client } from '../client';
 import { state as sdkConfigState } from './SdkConfigState';

--- a/packages/frontend-dist/src/view/AddSdkConfigModal.tsx
+++ b/packages/frontend-dist/src/view/AddSdkConfigModal.tsx
@@ -89,9 +89,6 @@ export class AddSdkConfigModal extends Component<
         {() => (
           <>
             <SdkConfigModal
-              submitButtonProps={{
-                children: sdkConfigId ? 'Update' : 'Add',
-              }}
               initialSdkConfig={
                 sdkConfigId
                   ? sdkConfigState.sdkConfigs.get(parseInt(sdkConfigId, 10))

--- a/packages/frontend-dist/src/view/AddSpecModal.tsx
+++ b/packages/frontend-dist/src/view/AddSpecModal.tsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 
 import {
   Button,
-  Typography,
   Dialog,
   DialogActions,
   DialogContent,

--- a/packages/frontend-dist/src/view/basic/SdkConfigBasicInfoForm.tsx
+++ b/packages/frontend-dist/src/view/basic/SdkConfigBasicInfoForm.tsx
@@ -1,0 +1,109 @@
+import React, { Component } from 'react';
+
+import {
+  FormControl,
+  FormHelperText,
+  Input,
+  InputLabel,
+  MenuItem,
+  Select,
+} from '@material-ui/core';
+import { Observer } from 'mobx-react';
+
+import { SDK_CONFIG_TARGETS } from '@openapi-platform/model';
+import { ValidatedFormStore } from '../../ValidatedFormStore';
+import { createStyled } from '../createStyled';
+
+const Styled: any = createStyled(theme => ({
+  optionsText: {
+    fontFamily: 'Roboto Mono',
+  },
+}));
+
+export interface SdkConfigBasicInfoFormProps {
+  inputStore: ValidatedFormStore<'target' | 'version' | 'options'>;
+}
+
+export class SdkConfigBasicInfoForm extends Component<SdkConfigBasicInfoFormProps> {
+  private onTargetChange = event =>
+    this.props.inputStore.setInputValue('target', event.target.value);
+  private onTargetBlur = () => this.props.inputStore.updateInputError('target');
+  private onVersionChange = event =>
+    this.props.inputStore.setInputValue('version', event.target.value);
+  private onVersionBlur = () => this.props.inputStore.updateInputError('version');
+  private onOptionsChange = event =>
+    this.props.inputStore.setInputValue('options', event.target.value);
+  private onOptionsBlur = () => this.props.inputStore.updateInputError('options');
+
+  public render() {
+    const { inputStore } = this.props;
+    return (
+      <Styled>
+        {({ classes }) => (
+          <Observer>
+            {() => (
+              <>
+                <FormControl
+                  error={inputStore.getInputError('target') !== null}
+                  margin="dense"
+                >
+                  <InputLabel htmlFor="target">Target</InputLabel>
+                  <Select
+                    onChange={this.onTargetChange}
+                    onBlur={this.onTargetBlur}
+                    value={inputStore.getInputValue('target')}
+                    inputProps={{
+                      id: 'target',
+                    }}
+                  >
+                    {SDK_CONFIG_TARGETS.map(targetName => (
+                      <MenuItem key={targetName} value={targetName}>
+                        {targetName}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  <FormHelperText>{inputStore.getInputError('target')}</FormHelperText>
+                </FormControl>
+                <FormControl
+                  error={inputStore.getInputError('version') !== null}
+                  margin="dense"
+                >
+                  <InputLabel htmlFor="version">Version</InputLabel>
+                  <Input
+                    id="version"
+                    onChange={this.onVersionChange}
+                    onBlur={this.onVersionBlur}
+                    value={inputStore.getInputValue('version')}
+                  />
+                  <FormHelperText>
+                    {inputStore.getInputError('version') || 'E.g. 1.2.34'}
+                  </FormHelperText>
+                </FormControl>
+                <FormControl
+                  error={inputStore.getInputError('options') !== null}
+                  margin="dense"
+                >
+                  <InputLabel htmlFor="options">Options</InputLabel>
+                  <Input
+                    id="options"
+                    className={classes.optionsText}
+                    onChange={this.onOptionsChange}
+                    onBlur={this.onOptionsBlur}
+                    value={inputStore.getInputValue('options')}
+                    multiline
+                    rows={5}
+                    rowsMax={10}
+                  />
+                  <FormHelperText>
+                    {inputStore.getInputError('options') ||
+                      'Target-specific options to pass to Swagger Codegen in JSON'}
+                  </FormHelperText>
+                </FormControl>
+              </>
+            )}
+          </Observer>
+        )}
+      </Styled>
+    );
+  }
+}

--- a/packages/frontend-dist/src/view/basic/SdkConfigGitInfoForm.tsx
+++ b/packages/frontend-dist/src/view/basic/SdkConfigGitInfoForm.tsx
@@ -1,0 +1,101 @@
+import React, { Component } from 'react';
+
+import { FormControl, FormHelperText, Input, InputLabel } from '@material-ui/core';
+import { Observer } from 'mobx-react';
+
+import { ValidatedFormStore } from '../../ValidatedFormStore';
+
+export interface SdkConfigGitInfoFormProps {
+  inputStore: ValidatedFormStore<'repoUrl' | 'repoBranch' | 'username' | 'accessToken'>;
+}
+
+export class SdkConfigGitInfoForm extends Component<SdkConfigGitInfoFormProps> {
+  private onRepoUrlChange = event =>
+    this.props.inputStore.setInputValue('repoUrl', event.target.value);
+  private onRepoUrlBlur = () => this.props.inputStore.updateInputError('repoUrl');
+  private onRepoBranchChange = event =>
+    this.props.inputStore.setInputValue('repoBranch', event.target.value);
+  private onRepoBranchBlur = () => this.props.inputStore.updateInputError('repoBranch');
+  private onUsernameChange = event =>
+    this.props.inputStore.setInputValue('username', event.target.value);
+  private onUsernameBlur = () => this.props.inputStore.updateInputError('username');
+  private onAccessTokenChange = event =>
+    this.props.inputStore.setInputValue('accessToken', event.target.value);
+  private onAccessTokenBlur = () => this.props.inputStore.updateInputError('accessToken');
+
+  public render() {
+    const { inputStore } = this.props;
+    return (
+      <Observer>
+        {() => (
+          <>
+            <FormControl
+              error={inputStore.getInputError('repoUrl') !== null}
+              margin="dense"
+            >
+              <InputLabel htmlFor="repoUrl">Repository URL</InputLabel>
+              <Input
+                id="repoUrl"
+                onChange={this.onRepoUrlChange}
+                onBlur={this.onRepoUrlBlur}
+                value={inputStore.getInputValue('repoUrl')}
+              />
+              <FormHelperText>
+                {inputStore.getInputError('repoUrl') ||
+                  'E.g. https://github.com/telstra/openapi-platform.git'}
+              </FormHelperText>
+            </FormControl>
+            <FormControl
+              error={inputStore.getInputError('repoBranch') !== null}
+              margin="dense"
+            >
+              <InputLabel htmlFor="repoBranch">Repository branch</InputLabel>
+              <Input
+                id="repoBranch"
+                onChange={this.onRepoBranchChange}
+                onBlur={this.onRepoBranchBlur}
+                value={inputStore.getInputValue('repoBranch')}
+              />
+              <FormHelperText>
+                {inputStore.getInputError('repoBranch') ||
+                  'Defaults the to main branch of the repository if not provided'}
+              </FormHelperText>
+            </FormControl>
+            <FormControl
+              error={inputStore.getInputError('username') !== null}
+              margin="dense"
+            >
+              <InputLabel htmlFor="username">Username</InputLabel>
+              <Input
+                id="username"
+                onChange={this.onUsernameChange}
+                onBlur={this.onUsernameBlur}
+                value={inputStore.getInputValue('username')}
+              />
+              <FormHelperText>
+                {inputStore.getInputError('username') ||
+                  'The username of the account to use when pushing'}
+              </FormHelperText>
+            </FormControl>
+            <FormControl
+              error={inputStore.getInputError('accessToken') !== null}
+              margin="dense"
+            >
+              <InputLabel htmlFor="accessToken">Personal access token</InputLabel>
+              <Input
+                id="accessToken"
+                onChange={this.onAccessTokenChange}
+                onBlur={this.onAccessTokenBlur}
+                value={inputStore.getInputValue('accessToken')}
+              />
+              <FormHelperText>
+                {inputStore.getInputError('accessToken') ||
+                  'A personal access token associated with the given username'}
+              </FormHelperText>
+            </FormControl>
+          </>
+        )}
+      </Observer>
+    );
+  }
+}

--- a/packages/frontend-dist/src/view/basic/SdkConfigModal.tsx
+++ b/packages/frontend-dist/src/view/basic/SdkConfigModal.tsx
@@ -3,21 +3,19 @@ import React, { Component } from 'react';
 import {
   Button,
   CircularProgress,
-  FormControl,
-  FormHelperText,
-  Input,
-  InputLabel,
-  MenuItem,
-  Select,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
+  Stepper,
+  Step,
+  StepButton,
 } from '@material-ui/core';
-import { ButtonProps } from '@material-ui/core/Button';
 import { DialogProps } from '@material-ui/core/Dialog';
 import { DialogTitleProps } from '@material-ui/core/DialogTitle';
+import { observable, action, computed } from 'mobx';
 import { Observer } from 'mobx-react';
+import { isWebUri } from 'valid-url';
 
 import { SDK_CONFIG_TARGETS, SdkConfig } from '@openapi-platform/model';
 import { AddedSdkConfig } from '../../state/SdkConfigState';
@@ -29,14 +27,13 @@ import {
   alwaysValid,
 } from '../../ValidatedFormStore';
 import { createStyled } from '../createStyled';
+import { SdkConfigBasicInfoForm } from './SdkConfigBasicInfoForm';
+import { SdkConfigGitInfoForm } from './SdkConfigGitInfoForm';
 
 const Styled: any = createStyled(theme => ({
   modalContent: {
     display: 'flex',
     flexDirection: 'column',
-  },
-  optionsText: {
-    fontFamily: 'Roboto Mono',
   },
   progressIndicator: {
     margin: `0 ${theme.spacing.unit * 4}px`,
@@ -50,8 +47,6 @@ export interface SdkConfigModalProps {
   readonly titleProps?: DialogTitleProps;
   readonly onCloseModal: OnCloseModal;
   readonly onSubmitSdkConfig: OnSubmitSdkConfig;
-  readonly cancelButtonProps?: ButtonProps;
-  readonly submitButtonProps?: ButtonProps;
   readonly showSubmitProgress?: boolean;
   readonly dialogProps?: DialogProps;
 }
@@ -62,170 +57,239 @@ export interface SdkConfigModalProps {
  */
 export class SdkConfigModal extends Component<SdkConfigModalProps> {
   /**
-   * Stores all form data and handles input validation logic.
+   * An array of all steps in the form, defining their name and content.
    */
-  private inputStore = new ValidatedFormStore({
-    target: {
-      validation: target =>
-        !SDK_CONFIG_TARGETS.includes(target)
-          ? inputInvalid('Error: Missing target')
-          : inputValid(),
-      initialValue: this.props.initialSdkConfig ? this.props.initialSdkConfig.target : '',
-    },
-    version: {
-      validation: alwaysValid,
-      initialValue:
-        this.props.initialSdkConfig && this.props.initialSdkConfig.version
-          ? this.props.initialSdkConfig.version
-          : '',
-    },
-    options: {
-      validation: options => {
-        try {
-          JSON.parse(options);
-          return inputValid();
-        } catch (e) {
-          return inputInvalid('Error: invalid JSON');
-        }
+  @observable
+  private steps = [
+    {
+      name: 'Basic Information',
+      inputStore: new ValidatedFormStore({
+        target: {
+          validation: target =>
+            !SDK_CONFIG_TARGETS.includes(target)
+              ? inputInvalid('Error: Missing target')
+              : inputValid(),
+          initialValue: this.props.initialSdkConfig
+            ? this.props.initialSdkConfig.target
+            : '',
+        },
+        version: {
+          validation: alwaysValid,
+          initialValue:
+            this.props.initialSdkConfig && this.props.initialSdkConfig.version
+              ? this.props.initialSdkConfig.version
+              : '',
+        },
+        options: {
+          validation: options => {
+            try {
+              JSON.parse(options);
+              return inputValid();
+            } catch (e) {
+              return inputInvalid('Error: invalid JSON');
+            }
+          },
+          initialValue:
+            this.props.initialSdkConfig && this.props.initialSdkConfig.options
+              ? JSON.stringify(this.props.initialSdkConfig.options, null, 2)
+              : '{}',
+        },
+      }),
+      render() {
+        return <SdkConfigBasicInfoForm inputStore={this.inputStore} />;
       },
-      initialValue:
-        this.props.initialSdkConfig && this.props.initialSdkConfig.options
-          ? JSON.stringify(this.props.initialSdkConfig.options, null, 2)
-          : '{}',
+      complete: false,
+      goToStep: () => this.goToStep(0),
     },
-  });
+    {
+      name: 'Git Repository',
+      inputStore: new ValidatedFormStore({
+        repoUrl: {
+          validation: repoUrl => {
+            if (!repoUrl) {
+              return inputInvalid('Error: URL cannot be empty');
+            } else if (!isWebUri(repoUrl)) {
+              return inputInvalid('Error: Invalid URL');
+            }
+            return inputValid();
+          },
+          initialValue:
+            this.props.initialSdkConfig && this.props.initialSdkConfig.gitInfo
+              ? this.props.initialSdkConfig.gitInfo.repoUrl
+              : '',
+        },
+        repoBranch: {
+          validation: alwaysValid,
+          initialValue:
+            this.props.initialSdkConfig &&
+            this.props.initialSdkConfig.gitInfo &&
+            this.props.initialSdkConfig.gitInfo.branch
+              ? this.props.initialSdkConfig.gitInfo.branch
+              : '',
+        },
+        username: {
+          validation: username =>
+            !username ? inputInvalid('Error: Missing username') : inputValid(),
+          initialValue:
+            this.props.initialSdkConfig &&
+            this.props.initialSdkConfig.gitInfo &&
+            this.props.initialSdkConfig.gitInfo.auth.username
+              ? this.props.initialSdkConfig.gitInfo.auth.username
+              : '',
+        },
+        accessToken: {
+          validation: accessToken =>
+            !accessToken
+              ? inputInvalid('Error: Missing personal access token')
+              : inputValid(),
+          initialValue:
+            this.props.initialSdkConfig &&
+            this.props.initialSdkConfig.gitInfo &&
+            this.props.initialSdkConfig.gitInfo.auth.token
+              ? this.props.initialSdkConfig.gitInfo.auth.token
+              : '',
+        },
+      }),
+      render() {
+        return <SdkConfigGitInfoForm inputStore={this.inputStore} />;
+      },
+      complete: false,
+      goToStep: () => this.goToStep(1),
+    },
+    {
+      name: 'File Cleanup',
+      inputStore: new ValidatedFormStore({}),
+      render: () => <div>TODO</div>,
+      complete: false,
+      goToStep: () => this.goToStep(2),
+    },
+    {
+      name: 'Readme Cleanup',
+      inputStore: new ValidatedFormStore({}),
+      render: () => <div>TODO</div>,
+      complete: false,
+      goToStep: () => this.goToStep(3),
+    },
+  ];
+
+  /**
+   * The current selected step in the form.
+   */
+  @observable
+  private currentStep: number = 0;
+
+  /**
+   * True if all steps but the last step have been completed, false otherwise.
+   */
+  @computed
+  private get allStepsCompleted(): boolean {
+    return this.steps.slice(0, -1).every(step => step.complete);
+  }
+
+  /**
+   * Goes to the given step in the form.
+   */
+  @action
+  private goToStep(step: number) {
+    // Validate input
+    if (this.steps[this.currentStep].inputStore.inputsValid) {
+      this.steps[this.currentStep].complete = true;
+    }
+    this.steps[step].complete = false;
+    this.currentStep = step;
+  }
+
+  /**
+   * Goes to the next step in the form.
+   */
+  private goToNextStep = () => {
+    // Validate input
+    if (!this.steps[this.currentStep].inputStore.inputsValid) {
+      this.steps[this.currentStep].inputStore.updateAllInputErrors();
+      return;
+    }
+    if (this.currentStep < this.steps.length - 1) {
+      this.goToStep(this.currentStep + 1);
+    } else {
+      this.steps[this.currentStep].complete = true;
+      this.onSubmitSdkConfig();
+    }
+  };
+
+  /**
+   * Goes to the previous step in the form.
+   */
+  private goToPreviousStep = () => {
+    if (this.currentStep > 0) {
+      this.goToStep(this.currentStep - 1);
+    }
+  };
 
   /**
    * Event fired when the user presses the 'Add' button.
    */
   private onSubmitSdkConfig() {
     // Validate input
-    if (!this.inputStore.inputsValid) {
-      this.inputStore.updateAllInputErrors();
+    if (!this.allStepsCompleted || !this.steps[this.steps.length - 1].complete) {
       return;
     }
 
-    // Send the request to the backend.
-    const target = this.inputStore.getInputValue('target');
-    const version = this.inputStore.getInputValue('version');
-    const options = JSON.parse(this.inputStore.getInputValue('options'));
+    // Send the request to the backend
+    const basicInfoInputStore = this.steps[0].inputStore as ValidatedFormStore<
+      'target' | 'version' | 'options'
+    >;
+    const target = basicInfoInputStore.getInputValue('target');
+    const version = basicInfoInputStore.getInputValue('version');
+    const options = JSON.parse(basicInfoInputStore.getInputValue('options'));
     // TODO: submittedSdkConfig.pushPath = "";
     this.props.onSubmitSdkConfig({ target, version, options });
   }
 
-  private onInputChange = event =>
-    this.inputStore.setInputValue(event.target.id, event.target.value);
-  private onInputBlur = event => this.inputStore.updateInputError(event.target.id);
-  private onTargetChange = event =>
-    this.inputStore.setInputValue('target', event.target.value);
-  private onTargetBlur = () => this.inputStore.updateInputError('target');
-
-  private onAddButtonClick = event => {
-    event.preventDefault();
-    this.onSubmitSdkConfig();
-  };
-
   public render() {
-    const {
-      onCloseModal,
-      titleProps,
-      dialogProps,
-      cancelButtonProps,
-      showSubmitProgress,
-      submitButtonProps,
-    } = this.props;
+    const { onCloseModal, titleProps, dialogProps, showSubmitProgress } = this.props;
     return (
       <Styled>
         {({ classes }) => (
           <Observer>
             {() => (
-              <Dialog
-                open
-                onClose={onCloseModal}
-                maxWidth="sm"
-                fullWidth
-                {...dialogProps}
-              >
+              <Dialog open onClose={onCloseModal} maxWidth="md" {...dialogProps}>
                 <form>
                   <DialogTitle {...titleProps} />
                   <DialogContent classes={{ root: classes.modalContent }}>
-                    <FormControl
-                      error={this.inputStore.getInputError('target') !== null}
-                      margin="dense"
-                    >
-                      <InputLabel htmlFor="target">Target</InputLabel>
-                      <Select
-                        onChange={this.onTargetChange}
-                        onBlur={this.onTargetBlur}
-                        value={this.inputStore.getInputValue('target')}
-                        inputProps={{
-                          id: 'target',
-                        }}
-                      >
-                        {SDK_CONFIG_TARGETS.map(target => (
-                          <MenuItem key={target} value={target}>
-                            {target}
-                          </MenuItem>
-                        ))}
-                      </Select>
-                      <FormHelperText>
-                        {this.inputStore.getInputError('target')}
-                      </FormHelperText>
-                    </FormControl>
-                    <FormControl
-                      error={this.inputStore.getInputError('version') !== null}
-                      margin="dense"
-                    >
-                      <InputLabel htmlFor="version">Version</InputLabel>
-                      <Input
-                        id="version"
-                        onChange={this.onInputChange}
-                        onBlur={this.onInputBlur}
-                        value={this.inputStore.getInputValue('version')}
-                      />
-                      <FormHelperText>
-                        {this.inputStore.getInputError('version') || 'E.g. 1.2.34'}
-                      </FormHelperText>
-                    </FormControl>
-                    <FormControl
-                      error={this.inputStore.getInputError('options') !== null}
-                      margin="dense"
-                    >
-                      <InputLabel htmlFor="options">Options</InputLabel>
-                      <Input
-                        id="options"
-                        className={classes.optionsText}
-                        onChange={this.onInputChange}
-                        onBlur={this.onInputBlur}
-                        value={this.inputStore.getInputValue('options')}
-                        multiline
-                        rows={5}
-                        rowsMax={10}
-                      />
-                      <FormHelperText>
-                        {this.inputStore.getInputError('options') ||
-                          'Target-specific options to pass to Swagger Codegen in JSON'}
-                      </FormHelperText>
-                    </FormControl>
+                    <Stepper nonLinear activeStep={this.currentStep}>
+                      {this.steps.map((step, index) => (
+                        <Step key={index}>
+                          <StepButton onClick={step.goToStep} completed={step.complete}>
+                            {step.name}
+                          </StepButton>
+                        </Step>
+                      ))}
+                    </Stepper>
+                    {this.steps[this.currentStep].render()}
                   </DialogContent>
                   <DialogActions>
-                    <Button
-                      color="primary"
-                      type="button"
-                      onClick={onCloseModal}
-                      {...cancelButtonProps}
-                    >
-                      Cancel
-                    </Button>
+                    {this.currentStep === 0 ? (
+                      <Button color="primary" onClick={onCloseModal}>
+                        Cancel
+                      </Button>
+                    ) : (
+                      <Button color="primary" onClick={this.goToPreviousStep}>
+                        Back
+                      </Button>
+                    )}
                     {showSubmitProgress ? (
                       <CircularProgress size={24} className={classes.progressIndicator} />
                     ) : (
                       <Button
                         color="primary"
-                        type="submit"
-                        onClick={this.onAddButtonClick}
-                        {...submitButtonProps}
-                      />
+                        onClick={this.goToNextStep}
+                        disabled={
+                          this.currentStep === this.steps.length - 1 &&
+                          !this.allStepsCompleted
+                        }
+                      >
+                        {this.currentStep === this.steps.length - 1 ? 'Done' : 'Next'}
+                      </Button>
                     )}
                   </DialogActions>
                 </form>
@@ -245,9 +309,6 @@ export const storybook: Category<SdkConfigModalProps> = {
       onCloseModal: () => {},
       onSubmitSdkConfig: () => {},
       showSubmitProgress: false,
-      submitButtonProps: {
-        children: 'Submit',
-      },
     },
   },
 };

--- a/packages/frontend-dist/src/view/basic/SdkConfigModal.tsx
+++ b/packages/frontend-dist/src/view/basic/SdkConfigModal.tsx
@@ -119,7 +119,18 @@ export class SdkConfigModal extends Component<SdkConfigModalProps> {
               : '',
         },
         repoBranch: {
-          validation: alwaysValid,
+          validation: (repoBranch, inputStore) => {
+            if (inputStore.getInputValue('repoUrl')) {
+              return inputValid();
+            } else {
+              // Make sure the repo branch isn't set if a repo URL isn't set
+              return repoBranch
+                ? inputInvalid(
+                    "Error: Can't specify a branch if a repository URL isn't also specified",
+                  )
+                : inputValid();
+            }
+          },
           initialValue:
             this.props.initialSdkConfig &&
             this.props.initialSdkConfig.gitInfo &&
@@ -136,7 +147,7 @@ export class SdkConfigModal extends Component<SdkConfigModalProps> {
               // Make sure the username isn't set if a repo URL isn't set
               return username
                 ? inputInvalid(
-                    "Error: Can't specify a username is a repository URL isn't also specified",
+                    "Error: Can't specify a username if a repository URL isn't also specified",
                   )
                 : inputValid();
             }
@@ -159,7 +170,7 @@ export class SdkConfigModal extends Component<SdkConfigModalProps> {
               // Make sure the access token isn't set if a repo URL isn't set
               return accessToken
                 ? inputInvalid(
-                    "Error: Can't specify a personal access token is a repository URL isn't also specified",
+                    "Error: Can't specify a personal access token if a repository URL isn't also specified",
                   )
                 : inputValid();
             }
@@ -177,20 +188,6 @@ export class SdkConfigModal extends Component<SdkConfigModalProps> {
       },
       complete: false,
       goToStep: () => this.goToStep(1),
-    },
-    {
-      name: 'File Cleanup',
-      inputStore: new ValidatedFormStore({}),
-      render: () => <div>TODO</div>,
-      complete: false,
-      goToStep: () => this.goToStep(2),
-    },
-    {
-      name: 'Readme Cleanup',
-      inputStore: new ValidatedFormStore({}),
-      render: () => <div>TODO</div>,
-      complete: false,
-      goToStep: () => this.goToStep(3),
     },
   ];
 
@@ -292,7 +289,13 @@ export class SdkConfigModal extends Component<SdkConfigModalProps> {
         {({ classes }) => (
           <Observer>
             {() => (
-              <Dialog open onClose={onCloseModal} maxWidth="md" {...dialogProps}>
+              <Dialog
+                open
+                onClose={onCloseModal}
+                maxWidth="sm"
+                fullWidth
+                {...dialogProps}
+              >
                 <form>
                   <DialogTitle {...titleProps} />
                   <DialogContent classes={{ root: classes.modalContent }}>

--- a/packages/frontend-dist/src/view/basic/SpecModal.tsx
+++ b/packages/frontend-dist/src/view/basic/SpecModal.tsx
@@ -16,9 +16,9 @@ import { ButtonProps } from '@material-ui/core/Button';
 import { DialogProps } from '@material-ui/core/Dialog';
 import { DialogTitleProps } from '@material-ui/core/DialogTitle';
 import { Observer } from 'mobx-react';
+import { isWebUri } from 'valid-url';
 
 import { Spec } from '@openapi-platform/model';
-import { isWebUri } from 'valid-url';
 import { Category } from '../../Storybook';
 import {
   ValidatedFormStore,
@@ -105,11 +105,6 @@ export class SpecModal extends Component<SpecModalProps> {
     this.inputStore.setInputValue(event.target.id, event.target.value);
   private onInputBlur = event => this.inputStore.updateInputError(event.target.id);
 
-  private onAddButtonClick = event => {
-    event.preventDefault();
-    this.onSubmitSpec();
-  };
-
   public render() {
     const {
       onCloseModal,
@@ -185,12 +180,7 @@ export class SpecModal extends Component<SpecModalProps> {
                     </FormControl>
                   </DialogContent>
                   <DialogActions>
-                    <Button
-                      color="primary"
-                      type="button"
-                      onClick={onCloseModal}
-                      {...cancelButtonProps}
-                    >
+                    <Button color="primary" onClick={onCloseModal} {...cancelButtonProps}>
                       Cancel
                     </Button>
                     {showSubmitProgress ? (
@@ -198,8 +188,7 @@ export class SpecModal extends Component<SpecModalProps> {
                     ) : (
                       <Button
                         color="primary"
-                        type="submit"
-                        onClick={this.onAddButtonClick}
+                        onClick={this.onSubmitSpec}
                         {...submitButtonProps}
                       />
                     )}

--- a/packages/frontend/src/build.ts
+++ b/packages/frontend/src/build.ts
@@ -1,8 +1,8 @@
 import webpack from 'webpack';
 
+import { apiBaseUrl } from '@openapi-platform/config';
 import createWebpackConfig from '../webpack.config';
 import { config } from './config';
-import { apiBaseUrl } from '@openapi-platform/config';
 import { logger } from './logger';
 
 export async function build({ ...webpackOptions } = {}) {

--- a/packages/model/src/SdkConfig.ts
+++ b/packages/model/src/SdkConfig.ts
@@ -26,7 +26,7 @@ export interface SdkConfig {
    * A full list of options for a given target language can be obtained from:
    * https://generator.swagger.io/api/gen/clients/<TARGET_LANGUAGE>
    */
-  options?: any;
+  options: any;
 
   /**
    * The current build status of the SDK.

--- a/packages/server/src/db/sdk-config-model.ts
+++ b/packages/server/src/db/sdk-config-model.ts
@@ -25,7 +25,7 @@ export function createSdkConfigModel(dbConnection: Sequelize.Sequelize) {
       },
       options: {
         type: Sequelize.JSON,
-        allowNull: true,
+        allowNull: false,
       },
       gitInfo: {
         type: Sequelize.JSON,

--- a/scripts/addDummyData.js
+++ b/scripts/addDummyData.js
@@ -19,16 +19,19 @@ async function addDummyData(specs, sdkConfigs) {
     {
       target: 'java',
       version: 'v1.0.0',
+      options: {},
       buildStatus: BuildStatus.NotRun,
     },
     {
       target: 'python',
       version: 'v1.0.0',
+      options: {},
       buildStatus: BuildStatus.NotRun,
     },
     {
       target: 'go',
       version: 'v1.0.0',
+      options: {},
       buildStatus: BuildStatus.NotRun,
     },
   );
@@ -43,16 +46,19 @@ async function addDummyData(specs, sdkConfigs) {
     {
       target: 'java',
       version: 'v1.0.0',
+      options: {},
       buildStatus: BuildStatus.NotRun,
     },
     {
       target: 'python',
       version: 'v1.0.0',
+      options: {},
       buildStatus: BuildStatus.NotRun,
     },
     {
       target: 'go',
       version: 'v1.0.0',
+      options: {},
       buildStatus: BuildStatus.NotRun,
     },
   );
@@ -66,16 +72,19 @@ async function addDummyData(specs, sdkConfigs) {
     {
       target: 'java',
       version: 'v1.0.34',
+      options: {},
       buildStatus: BuildStatus.Success,
     },
     {
       target: 'javascript',
       version: 'v1.0.35',
+      options: {},
       buildStatus: BuildStatus.Running,
     },
     {
       target: 'haskell-http-client',
       version: 'v0',
+      options: {},
       buildStatus: BuildStatus.NotRun,
     },
   );
@@ -88,6 +97,7 @@ async function addDummyData(specs, sdkConfigs) {
   await addToSpec(spec2, {
     target: 'go',
     version: 'alpha',
+    options: {},
     buildStatus: BuildStatus.Fail,
   });
   const spec3 = await specs.create({
@@ -101,11 +111,13 @@ async function addDummyData(specs, sdkConfigs) {
     {
       target: 'python',
       version: 'alpha',
+      options: {},
       buildStatus: BuildStatus.Success,
     },
     {
       target: 'java',
       version: 'alpha',
+      options: {},
       buildStatus: BuildStatus.Success,
     },
   );


### PR DESCRIPTION
This PR adds the ability to specify Git repository information for SDK configs. Currently only personal access tokens are supported as an authentication mechanism.

If an SDK config does not have any Git repository configured, then it will generate a ZIP file that can be downloaded. Otherwise, the generated SDK will be pushed directly to the specified repository.

This PR also makes it easy to add new steps to the `SdkConfigModal`, such as the planned cleanup options.

![image](https://user-images.githubusercontent.com/936267/45734798-2083f500-bc29-11e8-91c2-999bfb818324.png)
