### PR TITLE
Git util callbacks

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -3,11 +3,13 @@ import { createStories } from './createStories';
 import { withKnobs } from '@storybook/addon-knobs';
 import { checkA11y } from '@storybook/addon-a11y';
 import { setOptions } from '@storybook/addon-options';
-import withBackgrounds from '@storybook/addon-backgrounds';
+import { withViewport } from '@storybook/addon-viewport';
+import { withBackgrounds } from '@storybook/addon-backgrounds';
 import { addDecorator } from '@storybook/react';
 
 addDecorator(withKnobs);
 addDecorator(checkA11y);
+addDecorator(withViewport('responsive'));
 addDecorator(withBackgrounds());
 setOptions({
   name: 'OpenAPI Platform',

--- a/.storybook/createStories.tsx
+++ b/.storybook/createStories.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { basename } from 'path';
-// TODO: Should seperate purely UI things from the frontend-dist packages
-import { ThemeProvider } from '../packages/frontend-dist/src/view/ThemeProvider';
+import { ThemeProvider } from '@openapi-platform/frontend-dist/src/view/ThemeProvider';
 export function createStories(moduleInfo) {
   moduleInfo.forEach(({ path, requiredModule }) => {
     const storybookInfo = requiredModule.storybook;

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,5 +1,5 @@
-// TODO: Bit of a weird hack to go out and back into another package
-const createWebpackConfig = require('../packages/frontend/webpack.config');
+// TODO: Bit of a weird hack to into package like this
+const createWebpackConfig = require('@openapi-platform/frontend/webpack.config');
 const { DefinePlugin } = require('webpack');
 module.exports = (storybookConfig, configType) => {
   const frontendConfig = createWebpackConfig();
@@ -12,6 +12,5 @@ module.exports = (storybookConfig, configType) => {
   storybookConfig.plugins.push(
     ...frontendConfig.plugins.filter(plugin => plugin instanceof DefinePlugin),
   );
-  storybookConfig.plugins.forEach(console.log);
   return storybookConfig;
 };

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,7 @@ your machine:
 ## Quick start guide
 1. `git clone` the repository
 1. `yarn install` at the root of the project
-1. Add a configuration file to the root directory of the project
+1. Add a configuration file to the root directory of the project. Make sure to set `env` to `development`
 1. `yarn watch`
 1. Have at it :)
 
@@ -54,9 +54,9 @@ development:
 ## Building and Deploying
  * `yarn build` \
    Runs transpilation and bundling scripts to rebuild all packages. Runs in
-   `development` mode by default. To build for production, either set the `env`
+   `production` mode by default. To build for development, either set the `env`
    option in your configuration file or the `NODE_ENV` environment variable to
-   `production`.
+   `development`.
 
 ## Testing
  * `yarn test`

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -195,7 +195,6 @@ function restartServer(done) {
     backendNode.kill();
   }
   const backendEnv = Object.create(process.env);
-  backendEnv.NODE_ENV = 'development';
   backendNode = spawn(
     'node',
     [join(__dirname, 'packages/server/bin/start-openapi-platform-server.js')],

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -27,7 +27,7 @@ export const schema = convict({
     env: 'NODE_ENV',
     format: ['production', 'development', 'test'],
     arg: 'env',
-    default: 'development',
+    default: 'production',
   },
   ui: {
     protocol: {
@@ -66,7 +66,7 @@ export const schema = convict({
       */
       console: {
         level: logLevel({
-          default: 'info',
+          default: 'verbose',
           env: 'CONSOLE_LOG_LEVEL',
           arg: 'console-log-level',
         }),
@@ -133,7 +133,7 @@ export const schema = convict({
       env: 'DB_HOST',
       arg: 'db-host',
       format: '*',
-      default: undefined,
+      default: 'localhost',
     },
     port: {
       doc: 'The port of the PostgreSQL database to connect to.',

--- a/packages/git-util/src/hooks.ts
+++ b/packages/git-util/src/hooks.ts
@@ -23,26 +23,35 @@ export const hookKeys = [
   'cleanRepo',
   'extractSdk',
 ];
-export type HookOptions = { [key in HookKeys]?: Partial<Hook> };
+export interface HookOptions {
+  before?: Partial<Hooks>;
+  after?: Partial<Hooks>;
+}
 
-export type Hooks = { [key in HookKeys]: Hook };
+export interface CompleteHooksOptions {
+  before: Hooks;
+  after: Hooks;
+}
+
+export type Hooks = { [key in HookKeys]: HookCallback };
 
 export function defaultHook(): HookCallback {
   return async () => {};
 }
 
+export function withDefaultHooks(hooks: Partial<Hooks> = {}): Hooks {
+  return hookKeys.reduce((obj, key) => {
+    obj[key] = hooks[key] ? hooks[key] : defaultHook();
+    return obj;
+  }, {}) as Hooks;
+}
+
 /**
  * This lets us avoid having to do undefined checks everywhere
  */
-export function withDefaultHooks(hooks: HookOptions = {}): Hooks {
-  return hookKeys.reduce((obj, key) => {
-    const { before = defaultHook(), after = defaultHook() }: Hook = hooks[key]
-      ? hooks[key]
-      : {};
-    obj[key] = {
-      before,
-      after,
-    };
-    return obj;
-  }, {}) as Hooks;
+export function withDefaultHooksOptions(hooks: HookOptions = {}): CompleteHooksOptions {
+  return {
+    before: withDefaultHooks(hooks.before),
+    after: withDefaultHooks(hooks.after),
+  };
 }

--- a/packages/git-util/src/hooks.ts
+++ b/packages/git-util/src/hooks.ts
@@ -4,25 +4,16 @@ export interface Hook<B = any, BR = any, A = any, AR = any> {
   after: HookCallback<A, AR>;
 }
 
-export type HookKeys =
-  | 'stage'
-  | 'push'
-  | 'commit'
-  | 'clone'
-  | 'downloadSdk'
-  | 'moveSdkFilesToRepo'
-  | 'cleanRepo'
-  | 'extractSdk';
-export const hookKeys = [
-  'stage',
-  'push',
-  'commit',
-  'clone',
-  'downloadSdk',
-  'moveSdkFilesToRepo',
-  'cleanRepo',
-  'extractSdk',
-];
+export enum HookKeys {
+  stage = 'stage',
+  push = 'push',
+  commit = 'commit',
+  clone = 'clone',
+  downloadSdk = 'downloadSdk',
+  moveSdkFilesToRepo = 'moveSdkFilesToRepo',
+  cleanRepo = 'cleanRepo',
+  extractSdk = 'extractSdk',
+}
 export interface HookOptions {
   before?: Partial<Hooks>;
   after?: Partial<Hooks>;
@@ -40,10 +31,12 @@ export function defaultHook(): HookCallback {
 }
 
 export function withDefaultHooks(hooks: Partial<Hooks> = {}): Hooks {
-  return hookKeys.reduce((obj, key) => {
-    obj[key] = hooks[key] ? hooks[key] : defaultHook();
-    return obj;
-  }, {}) as Hooks;
+  return Object.keys(HookKeys)
+    .map(key => HookKeys[key])
+    .reduce((obj, key) => {
+      obj[key] = hooks[key] ? hooks[key] : defaultHook();
+      return obj;
+    }, {}) as Hooks;
 }
 
 /**

--- a/packages/git-util/src/hooks.ts
+++ b/packages/git-util/src/hooks.ts
@@ -1,0 +1,48 @@
+export type HookCallback<P = any | undefined, T = any> = (input: P) => Promise<T>;
+export interface Hook<B = any, BR = any, A = any, AR = any> {
+  before: HookCallback<B, BR>;
+  after: HookCallback<A, AR>;
+}
+
+export type HookKeys =
+  | 'stage'
+  | 'push'
+  | 'commit'
+  | 'clone'
+  | 'downloadSdk'
+  | 'moveSdkFilesToRepo'
+  | 'cleanRepo'
+  | 'extractSdk';
+export const hookKeys = [
+  'stage',
+  'push',
+  'commit',
+  'clone',
+  'downloadSdk',
+  'moveSdkFilesToRepo',
+  'cleanRepo',
+  'extractSdk',
+];
+export type HookOptions = { [key in HookKeys]?: Partial<Hook> };
+
+export type Hooks = { [key in HookKeys]: Hook };
+
+export function defaultHook(): HookCallback {
+  return async () => {};
+}
+
+/**
+ * This lets us avoid having to do undefined checks everywhere
+ */
+export function withDefaultHooks(hooks: HookOptions = {}): Hooks {
+  return hookKeys.reduce((obj, key) => {
+    const { before = defaultHook(), after = defaultHook() }: Hook = hooks[key]
+      ? hooks[key]
+      : {};
+    obj[key] = {
+      before,
+      after,
+    };
+    return obj;
+  }, {}) as Hooks;
+}

--- a/packages/git-util/src/index.ts
+++ b/packages/git-util/src/index.ts
@@ -71,7 +71,6 @@ export async function migrateSdkIntoLocalRepo(
 
   context.remoteSdkUrl = remoteSdkUrl;
   context.repoDir = repoDir;
-
   await hooks.before.cleanRepo(context);
   const deletedPaths = await deleteAllFilesInLocalRepo(context.repoDir);
   context.deletedPaths = deletedPaths;

--- a/packages/git-util/src/index.ts
+++ b/packages/git-util/src/index.ts
@@ -119,6 +119,8 @@ export async function updateRepoWithNewSdk(
   const hooks = withDefaultHooks(options.hooks);
   options.hooks = hooks;
 
+  context.gitInfo = gitInfo;
+  context.remoteSdkUrl = remoteSdkUrl;
   context.repoDir = await makeTempDir('repo');
   try {
     /*

--- a/packages/git-util/test/system/git.test.ts
+++ b/packages/git-util/test/system/git.test.ts
@@ -1,4 +1,4 @@
-import { withDefaultHooks } from '../../src/hooks';
+import { withDefaultHooksOptions } from '../../src/hooks';
 import { mockFunctions } from 'jest-mock-functions';
 // TODO: Would be really nice to have a in-memory-fs
 
@@ -47,7 +47,7 @@ describe('git', () => {
     it('valid inputs', async () => {
       // TODO: ES6 didn't work
       const { updateRepoWithNewSdk } = require('../../src');
-      const hooks = mockFunctions(withDefaultHooks(), { recursive: true });
+      const hooks = mockFunctions(withDefaultHooksOptions(), { recursive: true });
       // TODO: Need to test the outputs of this method
       await updateRepoWithNewSdk(
         {
@@ -59,11 +59,10 @@ describe('git', () => {
         "This SDK URL shouldn't be used",
         { hooks },
       );
-      Object.keys(hooks).forEach(key => {
-        console.log(key);
-        const hook = hooks[key];
-        expect(hook.before).toBeCalledTimes(1);
-        expect(hook.after).toBeCalledTimes(1);
+      ['before', 'after'].forEach(tense => {
+        Object.keys(hooks[tense]).forEach(hookKey => {
+          expect(hooks[tense][hookKey]).toBeCalledTimes(1);
+        });
       });
     });
   });

--- a/packages/git-util/test/system/git.test.ts
+++ b/packages/git-util/test/system/git.test.ts
@@ -1,13 +1,12 @@
-import { openapiLogger } from '@openapi-platform/logger';
-jest.mock('@openapi-platform/logger');
-
+import { withDefaultHooks } from '../../src/hooks';
+import { mockFunctions } from 'jest-mock-functions';
 // TODO: Would be really nice to have a in-memory-fs
 
 // Could put the following mocks in a __mocks__ folder but these mocks are somewhat specific to these tests
 jest.mock('isomorphic-git', () => {
   const actualModule = require.requireActual('isomorphic-git');
-  const { mockFunctions } = require('jest-mock-functions');
-  const mockedGitModule = mockFunctions(actualModule, {
+  const jestMockFunctions = require('jest-mock-functions');
+  const mockedGitModule = jestMockFunctions.mockFunctions(actualModule, {
     onMockedFunction: (fn, ogFn) => fn.mockImplementation((...other) => ogFn(...other)),
   });
   mockedGitModule.clone = jest.fn().mockImplementation((...options) => {
@@ -20,8 +19,8 @@ jest.mock('isomorphic-git', () => {
 
 jest.mock('../../src/file/index', () => {
   const actualModule = require.requireActual('../../src/file/index');
-  const { mockFunctions } = require('jest-mock-functions');
-  const mockedModule = mockFunctions(actualModule, {
+  const jestMockFunctions = require('jest-mock-functions');
+  const mockedModule = jestMockFunctions.mockFunctions(actualModule, {
     onMockedFunction: (fn, ogFn) => fn.mockImplementation((...other) => ogFn(...other)),
   });
   mockedModule.downloadToPath.mockImplementation(async path => {
@@ -35,7 +34,6 @@ jest.mock('../../src/file/index', () => {
   return mockedModule;
 });
 
-const logger = openapiLogger();
 /**
  * This is actually a test to make sure the other tests are going to work.
  */
@@ -46,10 +44,10 @@ it('temp dir actually works', async () => {
 
 describe('git', () => {
   describe('updateRepoWithNewSdk', () => {
-    it("doesn't crash", async () => {
+    it('valid inputs', async () => {
       // TODO: ES6 didn't work
       const { updateRepoWithNewSdk } = require('../../src');
-
+      const hooks = mockFunctions(withDefaultHooks(), { recursive: true });
       // TODO: Need to test the outputs of this method
       await updateRepoWithNewSdk(
         {
@@ -59,8 +57,14 @@ describe('git', () => {
           },
         },
         "This SDK URL shouldn't be used",
-        { logger },
+        { hooks },
       );
+      Object.keys(hooks).forEach(key => {
+        console.log(key);
+        const hook = hooks[key];
+        expect(hook.before).toBeCalledTimes(1);
+        expect(hook.after).toBeCalledTimes(1);
+      });
     });
   });
 });

--- a/packages/git-util/test/unit/hooks.test.ts
+++ b/packages/git-util/test/unit/hooks.test.ts
@@ -1,24 +1,20 @@
-import { withDefaultHooks, hookKeys } from '../../src/hooks';
+import { withDefaultHooksOptions, hookKeys } from '../../src/hooks';
 describe('withDefaultHooks', () => {
   it('adds default hooks', () => {
-    const hooks = withDefaultHooks();
-    Object.keys(hooks).forEach(key => {
-      const hook = hooks[key];
-      expect(hook).toEqual(
-        expect.objectContaining({
-          before: expect.any(Function),
-          after: expect.any(Function),
-        }),
-      );
+    const hooks = withDefaultHooksOptions();
+    ['before', 'after'].forEach(tense => {
+      Object.keys(hooks[tense]).forEach(key => {
+        expect(hooks[tense][key]).toEqual(expect.any(Function));
+      });
     });
   });
   it('does not replace existing hooks', () => {
     const beforeCommitCallback = async () => {};
-    const hooks = withDefaultHooks({
-      commit: {
-        before: beforeCommitCallback,
+    const hooks = withDefaultHooksOptions({
+      before: {
+        commit: beforeCommitCallback,
       },
     });
-    expect(hooks.commit.before).toBe(beforeCommitCallback);
+    expect(hooks.before.commit).toBe(beforeCommitCallback);
   });
 });

--- a/packages/git-util/test/unit/hooks.test.ts
+++ b/packages/git-util/test/unit/hooks.test.ts
@@ -1,0 +1,24 @@
+import { withDefaultHooks, hookKeys } from '../../src/hooks';
+describe('withDefaultHooks', () => {
+  it('adds default hooks', () => {
+    const hooks = withDefaultHooks();
+    Object.keys(hooks).forEach(key => {
+      const hook = hooks[key];
+      expect(hook).toEqual(
+        expect.objectContaining({
+          before: expect.any(Function),
+          after: expect.any(Function),
+        }),
+      );
+    });
+  });
+  it('does not replace existing hooks', () => {
+    const beforeCommitCallback = async () => {};
+    const hooks = withDefaultHooks({
+      commit: {
+        before: beforeCommitCallback,
+      },
+    });
+    expect(hooks.commit.before).toBe(beforeCommitCallback);
+  });
+});

--- a/packages/server/src/createServer.ts
+++ b/packages/server/src/createServer.ts
@@ -141,34 +141,40 @@ export async function createServer() {
           await updateRepoWithNewSdk(sdkConfig.gitInfo, sdk.path, {
             hooks: {
               clone: {
-                before: async hookContext => {
+                before: async gitHookContext => {
                   logger.verbose(
-                    `Cloning ${hookContext.remoteSdkUrl} into ${hookContext.repoDir}`,
+                    `Cloning ${gitHookContext.remoteSdkUrl} into ${
+                      gitHookContext.repoDir
+                    }`,
                   );
                 },
               },
               downloadSdk: {
-                before: async hookContext => {
+                before: async () => {
                   logger.verbose('Dowloading SDK');
                 },
               },
               extractSdk: {
-                before: async hookContext => {
+                before: async gitHookContext => {
                   logger.verbose(
-                    `Extracting ${hookContext.sdkArchivePath} to ${hookContext.sdkDir}`,
+                    `Extracting ${gitHookContext.sdkArchivePath} to ${
+                      gitHookContext.sdkDir
+                    }`,
                   );
                 },
               },
               moveSdkFilesToRepo: {
-                before: async hookContext => {
+                before: async gitHookContext => {
                   logger.verbose(
-                    `Moving files from ${hookContext.sdkDir} to ${hookContext.repoDir}`,
+                    `Moving files from ${gitHookContext.sdkDir} to ${
+                      gitHookContext.repoDir
+                    }`,
                   );
                 },
               },
               stage: {
-                before: async hookContext => {
-                  logger.verbose(`Staging ${hookContext.stagedPaths.length} paths`);
+                before: async gitHookContext => {
+                  logger.verbose(`Staging ${gitHookContext.stagedPaths.length} paths`);
                 },
               },
               commit: {

--- a/packages/server/src/createServer.ts
+++ b/packages/server/src/createServer.ts
@@ -140,51 +140,39 @@ export async function createServer() {
         if (sdkConfig.gitInfo) {
           await updateRepoWithNewSdk(sdkConfig.gitInfo, sdk.path, {
             hooks: {
-              clone: {
-                before: async gitHookContext => {
+              before: {
+                clone: async gitHookContext => {
                   logger.verbose(
                     `Cloning ${gitHookContext.remoteSdkUrl} into ${
                       gitHookContext.repoDir
                     }`,
                   );
                 },
-              },
-              downloadSdk: {
-                before: async () => {
+                downloadSdk: async () => {
                   logger.verbose('Dowloading SDK');
                 },
-              },
-              extractSdk: {
-                before: async gitHookContext => {
+                extractSdk: async gitHookContext => {
                   logger.verbose(
                     `Extracting ${gitHookContext.sdkArchivePath} to ${
                       gitHookContext.sdkDir
                     }`,
                   );
                 },
-              },
-              moveSdkFilesToRepo: {
-                before: async gitHookContext => {
+                moveSdkFilesToRepo: async gitHookContext => {
                   logger.verbose(
                     `Moving files from ${gitHookContext.sdkDir} to ${
                       gitHookContext.repoDir
                     }`,
                   );
                 },
-              },
-              stage: {
-                before: async gitHookContext => {
+                stage: async gitHookContext => {
                   logger.verbose(`Staging ${gitHookContext.stagedPaths.length} paths`);
                 },
-              },
-              commit: {
-                before: async () => {
+                commit: async () => {
                   // Maybe state the commit message and hash
                   logger.verbose(`Committing changes`);
                 },
-              },
-              push: {
-                before: async () => {
+                push: async () => {
                   logger.verbose(`Pushing commits...`);
                 },
               },

--- a/packages/server/test/integration/server.test.ts
+++ b/packages/server/test/integration/server.test.ts
@@ -190,6 +190,7 @@ describe('test server', () => {
           target: 'Kewl kids use Haskell',
           version: 'v1.1.1',
           buildStatus: BuildStatus.NotRun,
+          options: {},
         };
 
         const createdSdkConfig = await app.service('sdkConfigs').create(sdkConfigData);


### PR DESCRIPTION
## Proposed changes
The `logger` is no longer used directly inside of the `git-util` package. Instead, I've added a bunch of callbacks that fire at various stages of `updateRepoWithNewSdk`.
Added some tests to go with the new functionality too.

## Types of changes

What types of changes does your code introduce to OpenAPI Platform?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have signed and submitted the appropriate [CLA](../docs/contrib)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules