### PR TITLE
Now logging unhandled hook errors

### DIFF
--- a/packages/server/src/createServer.ts
+++ b/packages/server/src/createServer.ts
@@ -152,6 +152,12 @@ export async function createServer() {
     app.use(cors());
   }
 
+  app.hooks({
+    error(hook) {
+      logger.error(hook.error);
+    },
+  });
+
   // TODO: Use migrations instead of sync to create tables
   await specModel.sync();
   await sdkConfigModel.sync();


### PR DESCRIPTION
Turns out in order to log unhandled exceptions in feataherjs hooks, you need to explicitly state to log them. That's what this PR does.